### PR TITLE
Command Line Argument Parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,13 @@ For Huggingface cache management, refer to [hf_management.sh](./libs/dorie/hf_ma
 
 ## Contributing
 We welcome contributions from the community. Please refer to the `CONTRIBUTING.md` (TBD) file for guidelines on how to contribute to the project.
+## Citation
+```
+@misc{dorie2024,
+    title = {DORIE: Dynamic Omnichannel RoBERTa Intent Engine},
+    author = {Steven Loaiza},
+    year = {2024},
+    url = {https://github.com/loaizasteven/dorie},
+    description = {An advanced natural language processing system for multi-channel intent classification based on RoBERTa}
+}
+```

--- a/utils/cli.py
+++ b/utils/cli.py
@@ -1,0 +1,59 @@
+from functools import wraps
+from argparse import ArgumentParser
+from typing import Type, TypeVar, Callable
+import warnings
+
+from pydantic import BaseModel, Field
+
+T = TypeVar('T')
+
+def clap(cls: Type[T]) -> Callable[..., T]:
+    """Decorator that converts a class's type annotations into CLI arguments. Name is used to represent
+       Command Line Argument Parser (CLAP) like the Rust library."""
+    assert issubclass(cls, BaseModel), f"Class {cls.__name__} is not a Pydantic model. It is recommended to use Pydantic models for clap decorators."
+
+    @wraps(cls)
+    def wrapper(*args, **kwargs):
+        parser = ArgumentParser(description=cls.__doc__)
+        # Get class annotations and default values
+        annotations = cls.__annotations__
+        # Get descriptions from Pydantic fields if available
+        descriptions = {}
+        if hasattr(cls, 'model_fields'):
+            descriptions = {
+            name: field.description
+            for name, field in cls.model_fields.items()
+            if field.description is not None
+            }
+
+            defaults = {
+                name: field.default
+                for name, field in cls.model_fields.items()
+                if field.description is not None
+            }
+
+        # Add arguments
+        for name, type_hint in annotations.items():
+            parser.add_argument(
+                f'--{name}',
+                type=type_hint,
+                default=defaults.get(name),
+                help=descriptions.get(name),
+                required=name not in defaults
+            )
+        
+        # Parse and create instance
+        args = parser.parse_args()
+        return cls(**args.__dict__)
+    
+    return wrapper
+
+
+if __name__ == '__main__':
+    @clap
+    class MyArgs(BaseModel):
+        a: str = Field(..., description="This is a required argument")
+        b: str = Field(default='default_val',description="This is a required argument")
+    
+    args = MyArgs()
+    print(f"a: {args.a}, b: {args.b}")


### PR DESCRIPTION
# CLI Argument Parsing Feature

## Description
This pull request introduces a new CLI argument parsing feature using the clap decorator and pydantic's BaseModel. 

## Files Modified
- cli.py

## Testing
The script defines a class `MyArgs` with two arguments:
- `a`: Required argument
- `b`: Optional argument with default value
-
1. Run the script with required argument `a` and optional `b`
2. Verify argument parsing and handling

## Prerequisites
- Install clap and pydantic libraries

## Notes
- Update documentation when adding new arguments/features